### PR TITLE
Add a constructor for Context class and enhance storage phpdoc

### DIFF
--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -16,10 +16,22 @@ class Context implements Serializable
     /**
      * Storage for all context values
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $storage = [];
 
+    /**
+     * Context constructor
+     *
+     * @param array<string, mixed> $storage
+     */
+    public function __construct(array $storage = [])
+    {
+        foreach ($storage as $name => $value) {
+            $this->add($name, $value);
+        }    
+    }
+    
     /**
      * Add a context value. The key must be unique and cannot be replaced
      *
@@ -67,7 +79,7 @@ class Context implements Serializable
     /**
      * Get all context values (key => value pairs)
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function all()
     {

--- a/tests/Model/ContextTest.php
+++ b/tests/Model/ContextTest.php
@@ -25,6 +25,20 @@ class ContextTest extends TestCase
         static::assertEquals([], $context->all());
     }
 
+
+    /**
+     * Test passing storage to construct
+     *
+     * @return void
+     */
+    public function testConstructWithStorage()
+    {
+        $storage = ['foo' => 'bar', 'role' => 'ROLE_ADMIN'];
+
+        $context = new Context($storage);
+        static::assertEquals($storage, $context->all());
+    }
+
     /**
      * Test add context value
      *


### PR DESCRIPTION
Hello.

When you want to pass variables to constraint check you have to write several lines. 
I suggest to add a constructor on Context class to simplify it.

WDYT ?