### PR TITLE
provide type hint for ExpressionFunctionProviderInterface for Symfony 6.4 + 7.0 Support

### DIFF
--- a/src/Constraint/Provider/DateProvider.php
+++ b/src/Constraint/Provider/DateProvider.php
@@ -16,7 +16,7 @@ class DateProvider implements ExpressionFunctionProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return array(
             new ExpressionFunction(

--- a/src/Constraint/Provider/RatioProvider.php
+++ b/src/Constraint/Provider/RatioProvider.php
@@ -16,7 +16,7 @@ class RatioProvider implements ExpressionFunctionProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return array(
             new ExpressionFunction(


### PR DESCRIPTION
Add missing type implementation for Symfony 6.4 + 7.0 support. As `\Flagception\Constraint\Provider\MatchProvider` already upgraded, there should be no breaking changes.

This also allows the bundle to working with Symfony 6.4 / 7.0. Releasing a new new tag would nice, so a contribution on bundle repo can be done also.

![image](https://github.com/playox/flagception-sdk/assets/1011712/6a1d4c84-4160-4785-9277-ed1de66a8cc6)
