### PR TITLE
Fix PHP 8.4 deprecations and add some typing

### DIFF
--- a/src/Activator/ArrayActivator.php
+++ b/src/Activator/ArrayActivator.php
@@ -32,7 +32,7 @@ class ArrayActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'array';
     }
@@ -40,7 +40,7 @@ class ArrayActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         if (array_key_exists($name, $this->features)) {
             return filter_var($this->features[$name], FILTER_VALIDATE_BOOLEAN);

--- a/src/Activator/CacheActivator.php
+++ b/src/Activator/CacheActivator.php
@@ -67,7 +67,7 @@ class CacheActivator implements FeatureActivatorInterface
      *
      * @return FeatureActivatorInterface
      */
-    public function getActivator()
+    public function getActivator(): FeatureActivatorInterface
     {
         return $this->activator;
     }
@@ -75,7 +75,7 @@ class CacheActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->activator->getName();
     }
@@ -83,7 +83,7 @@ class CacheActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         $hash = static::CACHE_KEY . '#' . $this->getName() . '#' . md5($name . '-' . $context->serialize());
 

--- a/src/Activator/ChainActivator.php
+++ b/src/Activator/ChainActivator.php
@@ -46,7 +46,7 @@ class ChainActivator implements FeatureActivatorInterface
      *
      * @param int $strategy
      */
-    public function __construct($strategy = self::STRATEGY_FIRST_MATCH)
+    public function __construct(int $strategy = self::STRATEGY_FIRST_MATCH)
     {
         $this->strategy = $strategy;
     }
@@ -68,7 +68,7 @@ class ChainActivator implements FeatureActivatorInterface
      *
      * @return FeatureActivatorInterface[]
      */
-    public function getActivators()
+    public function getActivators(): array
     {
         return $this->bag;
     }
@@ -76,7 +76,7 @@ class ChainActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'chain';
     }
@@ -84,7 +84,7 @@ class ChainActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         $strategy = $context->get(self::CONTEXT_STRATEGY_NAME, $this->strategy);
 

--- a/src/Activator/ConstraintActivator.php
+++ b/src/Activator/ConstraintActivator.php
@@ -42,7 +42,7 @@ class ConstraintActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'constraint';
     }
@@ -50,7 +50,7 @@ class ConstraintActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         if (!array_key_exists($name, $this->features)) {
             return false;

--- a/src/Activator/CookieActivator.php
+++ b/src/Activator/CookieActivator.php
@@ -71,10 +71,10 @@ class CookieActivator implements FeatureActivatorInterface
      */
     public function __construct(
         array $features,
-        $name = 'flagception',
-        $separator = ',',
-        $mode = self::WHITELIST,
-        callable $extractor = null
+        string $name = 'flagception',
+        string $separator = ',',
+        string $mode = self::WHITELIST,
+        ?callable $extractor = null
     ) {
         if (!in_array($mode, [self::BLACKLIST, self::WHITELIST], true)) {
             throw new InvalidArgumentException(
@@ -103,7 +103,7 @@ class CookieActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'cookie';
     }
@@ -111,7 +111,7 @@ class CookieActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         // Disable features which aren't whitelisted
         if ($this->mode === self::WHITELIST && !in_array($name, $this->features, true)) {

--- a/src/Activator/EnvironmentActivator.php
+++ b/src/Activator/EnvironmentActivator.php
@@ -32,7 +32,7 @@ class EnvironmentActivator implements FeatureActivatorInterface
      * @param array $variables
      * @param bool $forceRequest
      */
-    public function __construct(array $variables = [], $forceRequest = false)
+    public function __construct(array $variables = [], bool $forceRequest = false)
     {
         $this->variables = $variables;
         $this->forceRequest = $forceRequest;
@@ -41,7 +41,7 @@ class EnvironmentActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'environment';
     }
@@ -49,7 +49,7 @@ class EnvironmentActivator implements FeatureActivatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context)
+    public function isActive(string $name, ?Context $context): bool
     {
         if ($this->forceRequest === false && !array_key_exists($name, $this->variables)) {
             return false;
@@ -69,7 +69,7 @@ class EnvironmentActivator implements FeatureActivatorInterface
      *
      * @return string|null
      */
-    private function getEnv($name)
+    private function getEnv($name): ?string
     {
         return filter_var(
             array_key_exists($name, $_ENV) ? $_ENV[$name] : getenv($name),

--- a/src/Activator/FeatureActivatorInterface.php
+++ b/src/Activator/FeatureActivatorInterface.php
@@ -17,16 +17,16 @@ interface FeatureActivatorInterface
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Check if the given feature name is active
      * Optional the context object can contain further options to check
      *
      * @param string $name
-     * @param Context $context
+     * @param Context|null $context
      *
      * @return bool
      */
-    public function isActive($name, Context $context);
+    public function isActive(string $name, ?Context $context): bool;
 }

--- a/src/Manager/FeatureManager.php
+++ b/src/Manager/FeatureManager.php
@@ -34,7 +34,7 @@ class FeatureManager implements FeatureManagerInterface
      * @param FeatureActivatorInterface $activator
      * @param ContextDecoratorInterface|null $decorator
      */
-    public function __construct(FeatureActivatorInterface $activator, ContextDecoratorInterface $decorator = null)
+    public function __construct(FeatureActivatorInterface $activator, ?ContextDecoratorInterface $decorator = null)
     {
         $this->activator = $activator;
         $this->decorator = $decorator;
@@ -43,7 +43,7 @@ class FeatureManager implements FeatureManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context = null)
+    public function isActive(string $name, ?Context $context = null): bool
     {
         if ($context === null) {
             $context = new Context();

--- a/src/Manager/FeatureManagerInterface.php
+++ b/src/Manager/FeatureManagerInterface.php
@@ -20,5 +20,5 @@ interface FeatureManagerInterface
      *
      * @return bool
      */
-    public function isActive($name, Context $context = null);
+    public function isActive(string $name, ?Context $context = null): bool;
 }

--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -24,6 +24,7 @@ class Context implements Serializable
      * Context constructor
      *
      * @param array<string, mixed> $storage
+     * @throws AlreadyDefinedException
      */
     public function __construct(array $storage = [])
     {
@@ -41,7 +42,7 @@ class Context implements Serializable
      * @return void
      * @throws AlreadyDefinedException
      */
-    public function add($name, $value)
+    public function add(string $name, $value)
     {
         if (array_key_exists($name, $this->storage)) {
             throw new AlreadyDefinedException(sprintf('Context value with key `%s` already defined', $name));
@@ -58,7 +59,7 @@ class Context implements Serializable
      *
      * @return void
      */
-    public function replace($name, $value)
+    public function replace(string $name, $value)
     {
         $this->storage[$name] = $value;
     }
@@ -71,7 +72,7 @@ class Context implements Serializable
      *
      * @return mixed
      */
-    public function get($name, $default = null)
+    public function get(string $name, $default = null)
     {
         return array_key_exists($name, $this->storage) ? $this->storage[$name] : $default;
     }
@@ -81,7 +82,7 @@ class Context implements Serializable
      *
      * @return array<string, mixed>
      */
-    public function all()
+    public function all(): array
     {
         return $this->storage;
     }
@@ -93,7 +94,7 @@ class Context implements Serializable
      *
      * @return bool
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return array_key_exists($name, $this->storage);
     }


### PR DESCRIPTION
Hello,

We're getting a

`Deprecated: Flagception\Manager\FeatureManager::__construct(): Implicitly marking parameter $decorator as nullable is deprecated, the explicit nullable type must be used instead in vendor/flagception/flagception/src/Manager/FeatureManager.php on line 37` deprecation message.

This is due to the `public function __construct(FeatureActivatorInterface $activator, ContextDecoratorInterface $decorator = null)` in `master/src/Manager/FeatureManager.php` not being PHP 8.4 compatible. More info about this deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

This pull request should fix this. I also added some extra typing. A pull request for the Symfony flagception bundle repository follows momentarily.